### PR TITLE
feat: into_inner for Csrf

### DIFF
--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -286,6 +286,14 @@ impl FromRequest for CsrfToken {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct Csrf<Inner>(Inner);
 
+impl<Inner> Csrf<Inner> {
+    /// Deconstruct to an inner value
+    #[must_use]
+    pub fn into_inner(self) -> Inner {
+        self.0
+    }
+}
+
 impl<Inner> Deref for Csrf<Inner> {
     type Target = Inner;
 


### PR DESCRIPTION
Both `web::Form` and `web::Json` provide a `into_inner()` function so you can get ownership of Inner.

I just integrated Csrf into our codebase and without `into_inner` i would need to clone a lot which isn't optimal, so would be nice if this could be included.